### PR TITLE
add __asm__(comment) to force replicate gotos

### DIFF
--- a/src/lvm.c
+++ b/src/lvm.c
@@ -749,7 +749,7 @@ void luaV_finishOp (lua_State *L) {
     lua_assert(base <= L->top && L->top < L->stack + L->stacksize); \
     {\
       void *label = dispatch_table[GET_OPCODE(i)];\
-      __asm__("# " __FILE__" %0" :: "i"(__LINE__));\
+      __asm__("# " __FILE__ " %0" :: "i"(__LINE__));\
       goto *label;\
     }
 

--- a/src/lvm.c
+++ b/src/lvm.c
@@ -740,6 +740,8 @@ void luaV_finishOp (lua_State *L) {
 #define vmlabel(l)   do_ ## l
 #define vmcase(l)   vmlabel(l):
 
+#define vmbreak_stringify_core(num) #num
+#define vmbreak_stringify(num_macro) vmbreak_stringify_core(num_macro)
 #define vmbreak \
     i = *(ci->u.l.savedpc++); \
     if (L->hookmask & (LUA_MASKLINE | LUA_MASKCOUNT)) \
@@ -749,7 +751,7 @@ void luaV_finishOp (lua_State *L) {
     lua_assert(base <= L->top && L->top < L->stack + L->stacksize); \
     {\
       void *label = dispatch_table[GET_OPCODE(i)];\
-      __asm__("# " __FILE__ " %0" :: "i"(__LINE__));\
+      __asm__("# " __FILE__ " " vmbreak_stringify(__LINE__));\
       goto *label;\
     }
 


### PR DESCRIPTION
This patch prevents  each 'vmbreak' being merged into one single place by gcc without '-fno-gcse' nor '-fno-crossjumping' options.
I used gcc-4.9.3(x86_64, x86_32 and ARM), and checked it's assembler output that has individual indirect jumps for every VM instructions.

Unfortunately, bench-marks on AMD FX-8350 show less difference than noises.
There was already no room left for improving branch prediction.
I used your bench mark.
https://github.com/starius/lang-bench/blob/master/f3/test.lua
and tested plain Lua-5.3.2, your computed-goto branch, and mine.
linux 'perf' tools show FX-8350 misses only 0.01% branches at these bench marks, including switch based plain Lua.
I wonder what on other processor.
